### PR TITLE
Handle case where the response is not json

### DIFF
--- a/lib/mailgun-email-validation.js
+++ b/lib/mailgun-email-validation.js
@@ -5,22 +5,20 @@ module.exports.check = function(email, callback) {
 	var options = {
 		url: config.url,
 		method: 'GET',
-		qs: { address: email },
+		qs: {
+			address: email
+		},
 		auth: {
 			username: config.username,
 			password: config.key
 		}
 	};
 
-	request(options, function(err, result) {
-		if (err) callback(err, null);
-		var response;
-		try {
-			response = JSON.parse(result.request.response.body);	
-		} catch (e) {
-			callback(new Error('Unable to parse response: ' + result.request.response.body), null);
-		}
-		
+	request(options, function(err, response, body) {
+		if (err) return callback(err, null);
+		if (response.statusCode !== 200) return callback('Received status ' + response.statusCode);
+
+		var response = JSON.parse(body);
 		callback(null, response.is_valid);
 	});
 };

--- a/lib/mailgun-email-validation.js
+++ b/lib/mailgun-email-validation.js
@@ -10,10 +10,17 @@ module.exports.check = function(email, callback) {
 			username: config.username,
 			password: config.key
 		}
-	}
+	};
+
 	request(options, function(err, result) {
 		if (err) callback(err, null);
-		var response = JSON.parse(result.request.response.body);
+		var response;
+		try {
+			response = JSON.parse(result.request.response.body);	
+		} catch (e) {
+			callback(new Error('Unable to parse response: ' + result.request.response.body), null);
+		}
+		
 		callback(null, response.is_valid);
 	});
 };

--- a/package.json
+++ b/package.json
@@ -40,12 +40,13 @@
     "url": "https://github.com/dimoreira/mailgun-email-validation/issues"
   },
   "devDependencies": {
-    "mocha": "^1.18.2",
     "expect.js": "^0.3.1",
-    "grunt-cli": "^0.1.13",
     "grunt": "^0.4.4",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.4.0",
-    "grunt-contrib-uglify": "^0.4.0"
+    "grunt-contrib-uglify": "^0.4.0",
+    "mocha": "^1.18.2",
+    "sinon": "^1.15.4"
   },
   "dependencies": {
     "request": "^2.34.0",

--- a/test/mailgun-email-validation_test.js
+++ b/test/mailgun-email-validation_test.js
@@ -1,5 +1,7 @@
 var expect = require('expect.js');
 var validator = require('../lib/mailgun-email-validation');
+var sinon = require('sinon');
+var request = require('request');
 
 describe('MailGun Email Validation', function() {
 
@@ -23,6 +25,50 @@ describe('MailGun Email Validation', function() {
 				if (err) throw err;
 				expect(valid).to.be(true);
 				done();
+			});
+		});
+
+		describe('with an error from the request', function() {
+			var errorMessage = 'some error';
+
+			var stub;
+			before(function() {
+				stub = sinon.stub(request, 'Request');
+				stub.yieldsTo('callback', errorMessage);
+			});
+
+			it('error in callback', function(done) {
+
+				validator.check('diegoalvesmoreira@gmail.com', function(err, valid) {
+					expect(err).to.equal(errorMessage);
+					done();
+				});
+			});
+
+			after(function() {
+				stub.restore();
+			});
+		});
+		
+		describe('with an error from the mailgun', function() {
+
+			var stub;
+			before(function() {
+				stub = sinon.stub(request, 'Request');
+				stub.yieldsTo('callback', null, {
+					statusCode: 401
+				});
+			});
+
+			it('401 from mailgun', function(done) {
+				validator.check('diegoalvesmoreira@gmail.com', function(err, valid) {
+					expect(err).to.equal('Received status 401');
+					done();
+				});
+			});
+
+			after(function() {
+				stub.restore();
 			});
 		});
 


### PR DESCRIPTION
During testing, where we do quite a few calls to validate emails, I have run into a problem where requests are rejected with a 401. This probably happens because I am doing too many requests. It exposed however that the status code is not checked, and it then fails parsing the JSON response.

At the same time the error checking doesn't return, so it continues to the parsing in that case also. This should fix both of those cases.